### PR TITLE
Update meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ spec:
      image: "quay.io/crw/plugin-intellij-rhel8:latest"
      mountSources: true
      volumes:
-         - mountPath: "/JetBrains/IdeaIC"
+         - mountPath: "/JetBrains/ideaIC"
            name: idea-configuration
      ports:
          - exposedPort: 8080


### PR DESCRIPTION
Update `mountPath` according to https://github.com/eclipse/che/issues/18269. `mountPath` had wrong path which prevented persistence of IntelliJ Idea configuration folder.